### PR TITLE
empty functions for optimizing material model parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,18 @@ version = "0.1.1"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+
+[weakdeps]
+Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
+
+[extensions]
+OptimizationContinuumMechanicsBaseExt = ["Optimization"]
 
 [compat]
 DocStringExtensions = "0.9"
+Optimization = "4.1.1"
 RecursiveArrayTools = "3"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ContinuumMechanicsBase"
 uuid = "3a778109-d974-46c8-ac54-09f30d605bdf"
 authors = ["Carson Farmer and Hector Medina"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/ext/OptimizationContinuumMechanicsBaseExt.jl
+++ b/ext/OptimizationContinuumMechanicsBaseExt.jl
@@ -5,7 +5,7 @@ using ContinuumMechanicsBase
 using DocStringExtensions
 using Optimization
 
-export parameters, parameter_bounds
+export parameters, parameter_bounds, MaterialOptimizationProblem
 
 
 """

--- a/ext/OptimizationContinuumMechanicsBaseExt.jl
+++ b/ext/OptimizationContinuumMechanicsBaseExt.jl
@@ -50,6 +50,21 @@ function parameter_bounds(
     return (lb = lb, ub = ub)
 end
 
+"""
+$(SIGNATURES)
+
+Creates an `OptimizationProblem` for use in [`Optimization.jl`](https://docs.sciml.ai/Optimization/stable/) to find the optimal parameters.
+
+# Arguments:
+- `ψ`: material model to use
+- `test` or `tests`: A single or vector of `::AbstractMaterialTest`s to use when fitting the parameters
+- `u₀`: Initial guess for parameters
+- `ps`: Any additional parameters for calling `predict()`
+- `adb`: Select differentiation type from [`ADTypes.jl`](https://github.com/SciML/ADTypes.jl). The type is automatically applied to the type of AD applied to the `OptimizationProblem` also.
+- `loss`: Loss function from [`LossFunctions.jl`](https://github.com/JuliaML/LossFunctions.jl)
+"""
+function MaterialOptimizationProblem end
+
 
 
 end # end of module

--- a/ext/OptimizationContinuumMechanicsBaseExt.jl
+++ b/ext/OptimizationContinuumMechanicsBaseExt.jl
@@ -13,7 +13,9 @@ $(TYPEDSIGNATURES)
 
 Empty function call of model parameters tuple for optimization.
 """
-function parameters(::M) where {M<:ContinuumMechanicsBase.AbstractMaterialModel} end
+function parameters(::M) where {M<:ContinuumMechanicsBase.AbstractMaterialModel}
+    @error "Method not implemented for model $M."
+end
 
 """
 $(TYPEDSIGNATURES)

--- a/ext/OptimizationContinuumMechanicsBaseExt.jl
+++ b/ext/OptimizationContinuumMechanicsBaseExt.jl
@@ -1,0 +1,55 @@
+module OptimizationContinuumMechanicsBaseExt
+
+
+using ContinuumMechanicsBase
+using DocStringExtensions
+using Optimization
+
+export parameters, parameter_bounds
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Empty function call of model parameters tuple for optimization.
+"""
+function parameters(::M) where {M<:ContinuumMechanicsBase.AbstractMaterialModel} end
+
+"""
+$(TYPEDSIGNATURES)
+
+Default bounds for each parameter in tuple for optimization.
+Without method dispatching for certain models, constants can be "optimized" in the range [-∞, ∞].
+Use discretion whether this is realistic.
+"""
+function parameter_bounds(::M, ::Any) where {M<:ContinuumMechanicsBase.AbstractMaterialModel}
+    lb = nothing
+    ub = nothing
+    return (lb = lb, ub = ub)
+end
+
+function parameter_bounds(
+            ψ       ::M,
+            tests   ::Vector{Any},
+        ) where {M<:ContinuumMechanicsBase.AbstractMaterialModel}
+    bounds = map(Base.Fix1(parameter_bounds, ψ), tests)
+    lbs = getfield.(bounds, :lb)
+    ubs = getfield.(bounds, :ub)
+    if !(eltype(lbs) <: Nothing)
+        lb_ps = fieldnames(eltype(lbs))
+        lb = map(p -> p .=> maximum(getfield.(lbs, p)), lb_ps) |> NamedTuple
+    else
+        lb = nothing
+    end
+    if !(eltype(ubs) <: Nothing)
+        ub_ps = fieldnames(eltype(ubs))
+        ub = map(p -> p .=> minimum(getfield.(ubs, p)), ub_ps) |> NamedTuple
+    else
+        ub = nothing
+    end
+    return (lb = lb, ub = ub)
+end
+
+
+
+end # end of module

--- a/src/ContinuumMechanicsBase.jl
+++ b/src/ContinuumMechanicsBase.jl
@@ -160,4 +160,16 @@ $(TYPEDSIGNATURES)
 """
 J(T::AbstractMatrix) = sqrt(det(T))
 
+
+## Material Optimization
+ext = Base.get_extension(@__MODULE__, :OptimizationContinuumMechanicsBaseExt)
+if !isnothing(ext)
+    export parameters, parameter_bounds, MaterialOptimizationProblem
+    parameters = ext.parameters
+    parameter_bounds = ext.parameter_bounds
+    MaterialOptimizationProblem = ext.MaterialOptimizationProblem
 end
+
+
+
+end # end of module


### PR DESCRIPTION
Could be helpful to create empty functions for future method dispatching on different material models. Given that these functions were already pretty generic (see [model_functions.jl](https://github.com/TRACER-LULab/Hyperelastics.jl/blob/0fbfeb356323bb73025fb1e74174e9b37235b039/src/model_functions.jl#L23) from Hyperelastics.jl), but just made a little bit more generic here.